### PR TITLE
Add outing scheduling component

### DIFF
--- a/pro-planner-client/package-lock.json
+++ b/pro-planner-client/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "bootstrap": "^5.3.0",
+        "date-fns": "^2.30.0",
         "react": "^18.2.0",
         "react-bootstrap": "^2.7.4",
         "react-bootstrap-icons": "^1.10.3",
@@ -6762,6 +6763,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {

--- a/pro-planner-client/package.json
+++ b/pro-planner-client/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "bootstrap": "^5.3.0",
+    "date-fns": "^2.30.0",
     "react": "^18.2.0",
     "react-bootstrap": "^2.7.4",
     "react-bootstrap-icons": "^1.10.3",

--- a/pro-planner-client/src/components/Day.css
+++ b/pro-planner-client/src/components/Day.css
@@ -14,6 +14,14 @@
     border-bottom: 1px solid rgb(172, 172, 172);
 }
 
-.selected {
+.top-segment {
+    border-top: 1px solid;
+}
+
+.left-segment {
+    border-left: 1px solid;
+}
+
+.selectable {
     background-color: white;
 }

--- a/pro-planner-client/src/components/Day.css
+++ b/pro-planner-client/src/components/Day.css
@@ -1,0 +1,19 @@
+.segment {
+    width: 100%;
+    height: 1em;
+    background-color: lightgrey;
+    border-bottom: 1px solid;
+    border-right: 1px solid;
+}
+
+.sub-segment {
+    width: 100%;
+    height: 1em;
+    background-color: lightgrey;
+    border-right: 1px solid;
+    border-bottom: 1px solid rgb(172, 172, 172);
+}
+
+.selected {
+    background-color: white;
+}

--- a/pro-planner-client/src/components/Day.jsx
+++ b/pro-planner-client/src/components/Day.jsx
@@ -1,6 +1,6 @@
 // descructuring references https://www.w3schools.com/react/react_es6_destructuring.asp
 import React from 'react';
-import { addMinutes, format, isAfter, isWithinInterval, startOfDay, endOfDay } from 'date-fns';
+import { addMinutes, format, isAfter, isWithinInterval, startOfDay, endOfDay, getDate } from 'date-fns';
 
 import './Day.css';
 
@@ -17,7 +17,7 @@ const isSegmentAvailable = (time, interval, additionalInterval) => {
 function Day({ availability }) {
   const segmentTotal = 60;
 
-  const {startInterval, endInterval, additionalStart, additionalEnd, isAvailable} = availability;
+  const { startInterval, endInterval, additionalStart, additionalEnd, isAvailable } = availability;
   let dayDisplay = [];
   let hourDisplay = [];
   let segmentTracker = segmentTotal;
@@ -44,10 +44,11 @@ function Day({ availability }) {
       hourDisplay = [];
       segmentTracker = segmentTotal;
     }
-} 
+  }
 
   return (
-    <div className="w-100 position-relative">
+    <div className="w-100 position-relative text-center">
+      {getDate(startInterval)}
       {dayDisplay}
     </div>
   );

--- a/pro-planner-client/src/components/Day.jsx
+++ b/pro-planner-client/src/components/Day.jsx
@@ -7,51 +7,60 @@ import './Day.css';
 const segmentInterval = 30; // should be some interval of 15 minutes
 
 const isSegmentAvailable = (time, interval, additionalInterval) => {
-  let result = isWithinInterval(time, { start: interval[0], end: addMinutes(interval[1], -1) });
-  if (additionalInterval[0] && !result) {
-    result = isWithinInterval(time, { start: additionalInterval[0], end: additionalInterval[0] });
-  }
-  return result;
+    let result = isWithinInterval(time, { start: interval[0], end: addMinutes(interval[1], -1) });
+    if (additionalInterval[0] && !result) {
+        result = isWithinInterval(time, { start: additionalInterval[0], end: additionalInterval[0] });
+    }
+    return result;
 };
 
-function Day({ availability }) {
-  const segmentTotal = 60;
+function Day({ availability, borderLeft = false }) {
+    let isFirstSegment = true; // For styling top of day
+    const segmentTotal = 60;
 
-  const { startInterval, endInterval, additionalStart, additionalEnd, isAvailable } = availability;
-  let dayDisplay = [];
-  let hourDisplay = [];
-  let segmentTracker = segmentTotal;
-  let timeTracker = startOfDay(startInterval);
-  const endOfCurrDay = endOfDay(startInterval);
+    const { startInterval, endInterval, additionalStart, additionalEnd, isAvailable } = availability;
+    let dayDisplay = [];
+    let hourDisplay = [];
+    let segmentTracker = segmentTotal;
+    let timeTracker = startOfDay(startInterval);
+    const endOfCurrDay = endOfDay(startInterval);
 
-  while (isAfter(endOfCurrDay, timeTracker)) {
-    const isSelectable = isAvailable ? isSegmentAvailable(timeTracker, [startInterval, endInterval], [additionalStart, additionalEnd]) : false;
-    hourDisplay.push(
-      <div
-        key={`${format(timeTracker, 'hh-mm')}`}
-        className={`${segmentTracker % segmentTotal ? 'segment' : 'sub-segment'} ${isSelectable ? 'selected' : ''}`}
-      />
-    );
+    while (isAfter(endOfCurrDay, timeTracker)) {
+        const isSelectable = isAvailable ? isSegmentAvailable(timeTracker, [startInterval, endInterval], [additionalStart, additionalEnd]) : false;
+        const segmentClass = [
+            segmentTracker % segmentTotal && 'segment',
+            !(segmentTracker % segmentTotal) && 'sub-segment',
+            isSelectable && 'selectable',
+            isFirstSegment && 'top-segment',
+            borderLeft && 'left-segment'
+        ].filter(Boolean).join(' ');
+        hourDisplay.push(
+            <div
+                key={`${format(timeTracker, 'hh-mm')}`}
+                className={segmentClass}
+            />
+        );
+        isFirstSegment = false;
 
-    timeTracker = addMinutes(timeTracker, segmentInterval);
-    segmentTracker -= segmentInterval;
-    if (segmentTracker <= 0) {
-      dayDisplay.push(
-        <div key={`hr-${timeTracker.getHours()}-${timeTracker.getMinutes()}`} className="hour-container">
-          {hourDisplay}
-        </div>
-      );
-      hourDisplay = [];
-      segmentTracker = segmentTotal;
+        timeTracker = addMinutes(timeTracker, segmentInterval);
+        segmentTracker -= segmentInterval;
+        if (segmentTracker <= 0) {
+            dayDisplay.push(
+                <div key={`hr-${timeTracker.getHours()}-${timeTracker.getMinutes()}`} className="hour-container">
+                    {hourDisplay}
+                </div>
+            );
+            hourDisplay = [];
+            segmentTracker = segmentTotal;
+        }
     }
-  }
 
-  return (
-    <div className="w-100 position-relative text-center">
-      {getDate(startInterval)}
-      {dayDisplay}
-    </div>
-  );
+    return (
+        <div className="w-100 position-relative text-center">
+            {getDate(startInterval)}
+            {dayDisplay}
+        </div>
+    );
 }
 
 export default Day;

--- a/pro-planner-client/src/components/Day.jsx
+++ b/pro-planner-client/src/components/Day.jsx
@@ -1,41 +1,54 @@
 // descructuring references https://www.w3schools.com/react/react_es6_destructuring.asp
 import React from 'react';
-import { addMinutes, set, isAfter, isWithinInterval } from 'date-fns';
+import { addMinutes, format, isAfter, isWithinInterval, startOfDay, endOfDay } from 'date-fns';
+
+import './Day.css';
 
 const segmentInterval = 30; // should be some interval of 15 minutes
 
 const isSegmentAvailable = (time, interval, additionalInterval) => {
-  let result = isWithinInterval(time, { start: interval[0], end: interval[1] });
+  let result = isWithinInterval(time, { start: interval[0], end: addMinutes(interval[1], -1) });
   if (additionalInterval[0] && !result) {
     result = isWithinInterval(time, { start: additionalInterval[0], end: additionalInterval[0] });
   }
   return result;
 };
 
-function Day({ startInterval, endInterval, additionalStart, additionalEnd, isAvailable }) {
+function Day({ availability }) {
   const segmentTotal = 60;
-  let segmentTracker = segmentTotal;
-  let timeTracker = set(startInterval, { hours: 0, minutes: 0, seconds: 0, milliseconds: 0 });
-  const endOfDay = set(startInterval, { hours: 23, minutes: 59, seconds: 59 });
+
+  const {startInterval, endInterval, additionalStart, additionalEnd, isAvailable} = availability;
   let dayDisplay = [];
   let hourDisplay = [];
-  while (isAfter(endOfDay, timeTracker)) {
-    console.log('asdf');
-    const isInAvailable = isAvailable ? isSegmentAvailable(timeTracker, [startInterval, endInterval], [additionalStart, additionalEnd]) : false;
-    hourDisplay.push(<div style={{ backgroundColor: isInAvailable ? 'red' : 'transparent' }}>{`hour-${timeTracker.getHours()}`}</div>);
+  let segmentTracker = segmentTotal;
+  let timeTracker = startOfDay(startInterval);
+  const endOfCurrDay = endOfDay(startInterval);
+
+  while (isAfter(endOfCurrDay, timeTracker)) {
+    const isSelectable = isAvailable ? isSegmentAvailable(timeTracker, [startInterval, endInterval], [additionalStart, additionalEnd]) : false;
+    hourDisplay.push(
+      <div
+        key={`${format(timeTracker, 'hh-mm')}`}
+        className={`${segmentTracker % segmentTotal ? 'segment' : 'sub-segment'} ${isSelectable ? 'selected' : ''}`}
+      />
+    );
 
     timeTracker = addMinutes(timeTracker, segmentInterval);
     segmentTracker -= segmentInterval;
     if (segmentTracker <= 0) {
-      dayDisplay.push(hourDisplay);
+      dayDisplay.push(
+        <div key={`hr-${timeTracker.getHours()}-${timeTracker.getMinutes()}`} className="hour-container">
+          {hourDisplay}
+        </div>
+      );
       hourDisplay = [];
+      segmentTracker = segmentTotal;
     }
-  }
+} 
+
   return (
-    <div>
-      {dayDisplay.map((hour) => (
-        <div>{hour}</div>
-      ))}
+    <div className="w-100 position-relative">
+      {dayDisplay}
     </div>
   );
 }

--- a/pro-planner-client/src/components/Day.jsx
+++ b/pro-planner-client/src/components/Day.jsx
@@ -1,0 +1,43 @@
+// descructuring references https://www.w3schools.com/react/react_es6_destructuring.asp
+import React from 'react';
+import { addMinutes, set, isAfter, isWithinInterval } from 'date-fns';
+
+const segmentInterval = 30; // should be some interval of 15 minutes
+
+const isSegmentAvailable = (time, interval, additionalInterval) => {
+  let result = isWithinInterval(time, { start: interval[0], end: interval[1] });
+  if (additionalInterval[0] && !result) {
+    result = isWithinInterval(time, { start: additionalInterval[0], end: additionalInterval[0] });
+  }
+  return result;
+};
+
+function Day({ startInterval, endInterval, additionalStart, additionalEnd, isAvailable }) {
+  const segmentTotal = 60;
+  let segmentTracker = segmentTotal;
+  let timeTracker = set(startInterval, { hours: 0, minutes: 0, seconds: 0, milliseconds: 0 });
+  const endOfDay = set(startInterval, { hours: 23, minutes: 59, seconds: 59 });
+  let dayDisplay = [];
+  let hourDisplay = [];
+  while (isAfter(endOfDay, timeTracker)) {
+    console.log('asdf');
+    const isInAvailable = isAvailable ? isSegmentAvailable(timeTracker, [startInterval, endInterval], [additionalStart, additionalEnd]) : false;
+    hourDisplay.push(<div style={{ backgroundColor: isInAvailable ? 'red' : 'transparent' }}>{`hour-${timeTracker.getHours()}`}</div>);
+
+    timeTracker = addMinutes(timeTracker, segmentInterval);
+    segmentTracker -= segmentInterval;
+    if (segmentTracker <= 0) {
+      dayDisplay.push(hourDisplay);
+      hourDisplay = [];
+    }
+  }
+  return (
+    <div>
+      {dayDisplay.map((hour) => (
+        <div>{hour}</div>
+      ))}
+    </div>
+  );
+}
+
+export default Day;

--- a/pro-planner-client/src/components/Hours.css
+++ b/pro-planner-client/src/components/Hours.css
@@ -1,0 +1,13 @@
+.hours {
+  margin: 9px 5px -1px 0;
+}
+
+.hours-container {
+  position: relative;
+  top: 1px;
+  text-align: center;
+}
+
+.next-btn {
+  margin-left: 3px;
+}

--- a/pro-planner-client/src/components/Hours.css
+++ b/pro-planner-client/src/components/Hours.css
@@ -1,13 +1,13 @@
 .hours {
-  margin: 9px 5px -1px 0;
+    margin: 9px 5px -1px 0;
 }
 
 .hours-container {
-  position: relative;
-  top: 1px;
-  text-align: center;
+    position: relative;
+    top: 1px;
+    text-align: center;
 }
 
 .next-btn {
-  margin-left: 3px;
+    margin-left: 3px;
 }

--- a/pro-planner-client/src/components/Hours.jsx
+++ b/pro-planner-client/src/components/Hours.jsx
@@ -1,0 +1,27 @@
+// code references https://date-fns.org/v2.30.0/docs/eachHourOfInterval
+// updating array references https://bobbyhadz.com/blog/javascript-modify-all-array-elements
+import { eachHourOfInterval, getHours } from 'date-fns';
+import React from 'react';
+import './Hours.css';
+
+function Hours() {
+  const hours = eachHourOfInterval({
+    start: new Date(2023, 9, 6, 0),
+    end: new Date(2023, 9, 6, 24),
+  });
+  hours.forEach((date, index) => {
+    hours[index] = getHours(date);
+  });
+  hours[hours.length - 1] = 24;
+  return (
+    <div className="hours-container">
+      {hours.map((hour, index) => (
+        <p key={index} className="hours">
+          {hour}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+export default Hours;

--- a/pro-planner-client/src/components/Hours.jsx
+++ b/pro-planner-client/src/components/Hours.jsx
@@ -1,27 +1,27 @@
 // code references https://date-fns.org/v2.30.0/docs/eachHourOfInterval
 // updating array references https://bobbyhadz.com/blog/javascript-modify-all-array-elements
-import { eachHourOfInterval, getHours } from 'date-fns';
 import React from 'react';
+import { eachHourOfInterval, getHours } from 'date-fns';
 import './Hours.css';
 
 function Hours() {
-  const hours = eachHourOfInterval({
-    start: new Date(2023, 9, 6, 0),
-    end: new Date(2023, 9, 6, 24),
-  });
-  hours.forEach((date, index) => {
-    hours[index] = getHours(date);
-  });
-  hours[hours.length - 1] = 24;
-  return (
-    <div className="hours-container">
-      {hours.map((hour, index) => (
-        <p key={index} className="hours">
-          {hour}
-        </p>
-      ))}
-    </div>
-  );
+    const hours = eachHourOfInterval({
+        start: new Date(2023, 9, 6, 0),
+        end: new Date(2023, 9, 6, 24),
+    });
+    hours.forEach((date, index) => {
+        hours[index] = getHours(date);
+    });
+    hours[hours.length - 1] = 24;
+    return (
+        <div className="hours-container">
+            {hours.map((hour, index) => (
+                <p key={index} className="hours">
+                    {`${hour}:00`}
+                </p>
+            ))}
+        </div>
+    );
 }
 
 export default Hours;

--- a/pro-planner-client/src/components/WeeklyCalandar.jsx
+++ b/pro-planner-client/src/components/WeeklyCalandar.jsx
@@ -2,7 +2,7 @@
 // adding days to date references https://stackoverflow.com/questions/563406/how-to-add-days-to-date
 // code references https://date-fns.org/docs/Getting-Started
 
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { addWeeks, isWithinInterval, addDays, startOfWeek } from 'date-fns';
 import { processDates, getWeekInterval } from '../helpers/Outing';
@@ -10,40 +10,34 @@ import Day from './Day';
 
 function WeeklyCalandar() {
   const startTime = new Date('2023-06-03, 01:00:00');
-  const endTime = new Date('2023-06-03, 03:00:00');
-  const endDate = new Date('2023-06-9, 03:00:00');
+  const endTime = new Date('2023-06-03, 11:00:00');
+  const endDate = new Date('2023-06-9, 11:00:00');
   const params = {
     availableDays: [0, 1, 2, 5, 6],
     dateTimeRange: [[startTime, endTime], endDate],
   };
-  let dates = processDates(params);
-  console.log(dates);
+  const [selectWeek, setSelectWeek] = useState(1);
 
-  const weekStart = startOfWeek(startTime);
-  let currWeekInterval = getWeekInterval(weekStart);
+  let dates = processDates(params);
 
   const calendarDisplay = [];
   let currWeek = [];
-
-  for (const date of dates) {
-    if (isWithinInterval(date.startInterval, { start: currWeekInterval[0], end: currWeekInterval[1] })) {
-      currWeek.push(date);
-    } else {
+  let weekCount = 0;
+  for (const availability of dates) {
+    currWeek.push(availability);
+    weekCount++;
+    if (weekCount >= 7) {
       calendarDisplay.push(currWeek);
-      currWeekInterval = [addDays(currWeekInterval[0], 8), addDays(currWeekInterval[1], 8)];
       currWeek = [];
+      weekCount = 0;
     }
   }
 
+  console.log(calendarDisplay);
+
   return (
-    <div>
-      {calendarDisplay.map((week) => (
-        <div>
-          {week.map((date) => (
-            <Day day={date} />
-          ))}
-        </div>
-      ))}
+    <div className="d-flex w-75 m-auto">
+      {calendarDisplay[selectWeek].map((availability) => <Day availability={availability} />)}
     </div>
   );
   // let showDays = dates.map((day) => <Day day={day} />);

--- a/pro-planner-client/src/components/WeeklyCalandar.jsx
+++ b/pro-planner-client/src/components/WeeklyCalandar.jsx
@@ -1,0 +1,52 @@
+// getting date info referencs https://stackoverflow.com/questions/47607666/how-to-extract-only-time-from-iso-date-format-in-javascript
+// adding days to date references https://stackoverflow.com/questions/563406/how-to-add-days-to-date
+// code references https://date-fns.org/docs/Getting-Started
+
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { addWeeks, isWithinInterval, addDays, startOfWeek } from 'date-fns';
+import { processDates, getWeekInterval } from '../helpers/Outing';
+import Day from './Day';
+
+function WeeklyCalandar() {
+  const startTime = new Date('2023-06-03, 01:00:00');
+  const endTime = new Date('2023-06-03, 03:00:00');
+  const endDate = new Date('2023-06-9, 03:00:00');
+  const params = {
+    availableDays: [0, 1, 2, 5, 6],
+    dateTimeRange: [[startTime, endTime], endDate],
+  };
+  let dates = processDates(params);
+  console.log(dates);
+
+  const weekStart = startOfWeek(startTime);
+  let currWeekInterval = getWeekInterval(weekStart);
+
+  const calendarDisplay = [];
+  let currWeek = [];
+
+  for (const date of dates) {
+    if (isWithinInterval(date.startInterval, { start: currWeekInterval[0], end: currWeekInterval[1] })) {
+      currWeek.push(date);
+    } else {
+      calendarDisplay.push(currWeek);
+      currWeekInterval = [addDays(currWeekInterval[0], 8), addDays(currWeekInterval[1], 8)];
+      currWeek = [];
+    }
+  }
+
+  return (
+    <div>
+      {calendarDisplay.map((week) => (
+        <div>
+          {week.map((date) => (
+            <Day day={date} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+  // let showDays = dates.map((day) => <Day day={day} />);
+  // return <div>{showDays}</div>;
+}
+export default WeeklyCalandar;

--- a/pro-planner-client/src/components/WeeklyCalandar.jsx
+++ b/pro-planner-client/src/components/WeeklyCalandar.jsx
@@ -5,67 +5,63 @@
 // conditional className references https://stackoverflow.com/questions/30533171/react-js-conditionally-applying-class-attributes
 
 import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
-import { addWeeks, isWithinInterval, addDays, startOfWeek } from 'date-fns';
-import { processDates, getWeekInterval } from '../helpers/Outing';
+import { format } from 'date-fns';
+import { processDates } from '../helpers/Outing';
 import Day from './Day';
 import Hours from './Hours';
 import Button from 'react-bootstrap/Button';
 
 function WeeklyCalandar() {
-  const startTime = new Date('2023-06-03, 01:00:00');
-  const endTime = new Date('2023-06-03, 11:00:00');
-  const endDate = new Date('2023-06-9, 11:00:00');
-  const params = {
-    availableDays: [0, 1, 2, 5, 6],
-    dateTimeRange: [[startTime, endTime], endDate],
-  };
-  const [selectWeek, setSelectWeek] = useState(0);
+    const startTime = new Date('2023-06-03, 01:00:00');
+    const endTime = new Date('2023-06-03, 23:00:00');
+    const endDate = new Date('2023-06-21, 23:00:00');
+    const params = {
+        availableDays: [0, 1, 3, 5, 6],
+        dateTimeRange: [[startTime, endTime], endDate],
+    };
+    const [selectWeek, setSelectWeek] = useState(0);
 
-  let dates = processDates(params);
+    let dates = processDates(params);
 
-  const calendarDisplay = [];
-  let currWeek = [];
-  let weekCount = 0;
-  for (const availability of dates) {
-    currWeek.push(availability);
-    weekCount++;
-    if (weekCount >= 7) {
-      calendarDisplay.push(currWeek);
-      currWeek = [];
-      weekCount = 0;
+    const calendarDisplay = [];
+    let currWeek = [];
+    let weekCount = 0;
+    for (const availability of dates) {
+        currWeek.push(availability);
+        weekCount++;
+        if (weekCount >= 7) {
+            calendarDisplay.push(currWeek);
+            currWeek = [];
+            weekCount = 0;
+        }
     }
-  }
 
-  console.log(calendarDisplay);
-
-  function changeWeek(type) {
-    if (type) {
-      setSelectWeek(selectWeek + 1);
-    } else {
-      setSelectWeek(selectWeek - 1);
+    function changeWeek(type) {
+        if (type) {
+            setSelectWeek(selectWeek + 1);
+        } else {
+            setSelectWeek(selectWeek - 1);
+        }
     }
-  }
 
-  return (
-    <div className="d-flex flex-column w-75 m-auto">
-      <div className="d-flex">
-        <Hours />
-        {calendarDisplay[selectWeek].map((availability, index) => (
-          <Day key={index} availability={availability} />
-        ))}
-      </div>
-      <div className="d-flex justify-content-end">
-        <Button onClick={() => changeWeek(false)} className={selectWeek !== 0 ? '' : 'disabled'}>
-          Prev
-        </Button>
-        <Button onClick={() => changeWeek(true)} className={'next-btn ' + (calendarDisplay.length - 1 > selectWeek ? '' : 'disabled')}>
-          Next
-        </Button>
-      </div>
-    </div>
-  );
-  // let showDays = dates.map((day) => <Day day={day} />);
-  // return <div>{showDays}</div>;
+    return (
+        <div className="d-flex flex-column w-75 m-auto">
+            <h3>{format(calendarDisplay[selectWeek][0].startInterval, 'MMMM')}</h3>
+            <div className="d-flex">
+                <Hours />
+                {calendarDisplay[selectWeek].map((availability, index) => (
+                    <Day key={`day-${index}`} availability={availability} borderLeft={index === 0} />
+                ))}
+            </div>
+            <div className="d-flex justify-content-end">
+                <Button onClick={() => changeWeek(false)} className={selectWeek !== 0 ? '' : 'disabled'}>
+                    Prev
+                </Button>
+                <Button onClick={() => changeWeek(true)} className={'next-btn ' + (calendarDisplay.length - 1 > selectWeek ? '' : 'disabled')}>
+                    Next
+                </Button>
+            </div>
+        </div>
+    );
 }
 export default WeeklyCalandar;

--- a/pro-planner-client/src/components/WeeklyCalandar.jsx
+++ b/pro-planner-client/src/components/WeeklyCalandar.jsx
@@ -1,12 +1,16 @@
 // getting date info referencs https://stackoverflow.com/questions/47607666/how-to-extract-only-time-from-iso-date-format-in-javascript
 // adding days to date references https://stackoverflow.com/questions/563406/how-to-add-days-to-date
 // code references https://date-fns.org/docs/Getting-Started
+// disable button references https://stackoverflow.com/questions/38196743/conditionally-set-the-disabled-state-of-a-bootstrap-button
+// conditional className references https://stackoverflow.com/questions/30533171/react-js-conditionally-applying-class-attributes
 
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { addWeeks, isWithinInterval, addDays, startOfWeek } from 'date-fns';
 import { processDates, getWeekInterval } from '../helpers/Outing';
 import Day from './Day';
+import Hours from './Hours';
+import Button from 'react-bootstrap/Button';
 
 function WeeklyCalandar() {
   const startTime = new Date('2023-06-03, 01:00:00');
@@ -16,7 +20,7 @@ function WeeklyCalandar() {
     availableDays: [0, 1, 2, 5, 6],
     dateTimeRange: [[startTime, endTime], endDate],
   };
-  const [selectWeek, setSelectWeek] = useState(1);
+  const [selectWeek, setSelectWeek] = useState(0);
 
   let dates = processDates(params);
 
@@ -35,9 +39,30 @@ function WeeklyCalandar() {
 
   console.log(calendarDisplay);
 
+  function changeWeek(type) {
+    if (type) {
+      setSelectWeek(selectWeek + 1);
+    } else {
+      setSelectWeek(selectWeek - 1);
+    }
+  }
+
   return (
-    <div className="d-flex w-75 m-auto">
-      {calendarDisplay[selectWeek].map((availability) => <Day availability={availability} />)}
+    <div className="d-flex flex-column w-75 m-auto">
+      <div className="d-flex">
+        <Hours />
+        {calendarDisplay[selectWeek].map((availability, index) => (
+          <Day key={index} availability={availability} />
+        ))}
+      </div>
+      <div className="d-flex justify-content-end">
+        <Button onClick={() => changeWeek(false)} className={selectWeek !== 0 ? '' : 'disabled'}>
+          Prev
+        </Button>
+        <Button onClick={() => changeWeek(true)} className={'next-btn ' + (calendarDisplay.length - 1 > selectWeek ? '' : 'disabled')}>
+          Next
+        </Button>
+      </div>
     </div>
   );
   // let showDays = dates.map((day) => <Day day={day} />);

--- a/pro-planner-client/src/helpers/Outing.js
+++ b/pro-planner-client/src/helpers/Outing.js
@@ -90,7 +90,7 @@ export function processDates(params) {
   }
 
   while (isAfter(endOfWeek(endDate), currDate)) {
-    dates.push({ isAvailable: false, currDate });
+    dates.push({ isAvailable: false, startInterval: currDate });
     currDate = addDays(currDate, 1);
   }
   return dates;

--- a/pro-planner-client/src/helpers/Outing.js
+++ b/pro-planner-client/src/helpers/Outing.js
@@ -1,107 +1,107 @@
 // code references https://date-fns.org/docs/Getting-Started
 
-import { isAfter, set, getDay, getHours, getMinutes, addDays, getDate, startOfWeek, endOfWeek, startOfDay, endOfDay } from 'date-fns';
+import { isAfter, set, getDay, getHours, getMinutes, addDays, getDate, startOfWeek, endOfWeek, startOfDay } from 'date-fns';
 
 export function processDates(params) {
-  const startInterval = params.dateTimeRange[0][0];
-  const endInterval = params.dateTimeRange[0][1];
-  const endDate = params.dateTimeRange[1];
+    const startInterval = params.dateTimeRange[0][0];
+    const endInterval = params.dateTimeRange[0][1];
+    const endDate = params.dateTimeRange[1];
 
-  let nextDayOverFlow = false;
-  if (getDate(startInterval) !== getDate(endInterval)) {
-    nextDayOverFlow = true;
-  }
+    let nextDayOverFlow = false;
+    if (getDate(startInterval) !== getDate(endInterval)) {
+        nextDayOverFlow = true;
+    }
 
-  let startWeekForInterval = startOfWeek(startInterval);
+    let startWeekForInterval = startOfWeek(startInterval);
 
-  let datesIndex = 0;
-  let dates = [];
-  while (getDay(startInterval) !== getDay(startWeekForInterval)) {
-    dates[datesIndex] = {
-      isAvailable: false,
-      startInterval: startWeekForInterval,
-    };
-    startWeekForInterval = addDays(startWeekForInterval, 1);
+    let datesIndex = 0;
+    let dates = [];
+    while (getDay(startInterval) !== getDay(startWeekForInterval)) {
+        dates[datesIndex] = {
+            isAvailable: false,
+            startInterval: startWeekForInterval,
+        };
+        startWeekForInterval = addDays(startWeekForInterval, 1);
+        datesIndex++;
+    }
+
+    dates.push({
+        isAvailable: true,
+        startInterval: startInterval,
+        endInterval: endInterval,
+    });
     datesIndex++;
-  }
-
-  dates.push({
-    isAvailable: true,
-    startInterval: startInterval,
-    endInterval: endInterval,
-  });
-  datesIndex++;
-  if (nextDayOverFlow) {
-    dates[0].endInterval = startInterval(startInterval);
-  }
-  let currDate = addDays(startInterval, 1);
-  let tempStartInterval = startInterval;
-  let tempEndInterval = endInterval;
-
-  let dayOfWeekIndex = getDay(startInterval) === 6 ? 0 : getDay(startInterval) + 1;
-
-  let firstDay = true;
-  while (!isAfter(currDate, endDate)) {
-    dates[datesIndex] = {};
-    if (params.availableDays.includes(dayOfWeekIndex)) {
-      dates[datesIndex].isAvailable = true;
-    } else {
-      dates[datesIndex].isAvailable = false;
+    if (nextDayOverFlow) {
+        dates[0].endInterval = startInterval(startInterval);
     }
-    dayOfWeekIndex++;
-    if (dayOfWeekIndex === 7) {
-      dayOfWeekIndex = 0;
-    }
+    let currDate = addDays(startInterval, 1);
+    let tempStartInterval = startInterval;
+    let tempEndInterval = endInterval;
 
-    if (dates[datesIndex].isAvailable) {
-      if (nextDayOverFlow) {
-        if (!firstDay) {
-          let additionalStartInterval = startOfDay(currDate);
-          let additionalEndInterval = set(new Date(), {
-            date: getDate(currDate),
-            hours: getHours(endInterval),
-            minutes: getMinutes(endInterval),
-            seconds: getHours(endInterval),
-            milliseconds: getHours(endInterval),
-          });
-          dates[datesIndex].additionalStart = additionalStartInterval;
-          dates[datesIndex].additionalEnd = additionalEndInterval;
+    let dayOfWeekIndex = getDay(startInterval) === 6 ? 0 : getDay(startInterval) + 1;
+
+    let firstDay = true;
+    while (!isAfter(currDate, endDate)) {
+        dates[datesIndex] = {};
+        if (params.availableDays.includes(dayOfWeekIndex)) {
+            dates[datesIndex].isAvailable = true;
+        } else {
+            dates[datesIndex].isAvailable = false;
         }
-        tempStartInterval = setInterval(tempStartInterval, currDate);
-        tempEndInterval = set(new Date(), {
-          date: getDate(currDate),
-          hours: 23,
-          minutes: 59,
-          seconds: 59,
-          milliseconds: 59,
-        });
-        dates[datesIndex].startInterval = tempStartInterval;
-        dates[datesIndex].endInterval = tempEndInterval;
-      } else {
-        tempStartInterval = setInterval(tempStartInterval, currDate);
-        tempEndInterval = setInterval(tempEndInterval, currDate);
-        dates[datesIndex].startInterval = tempStartInterval;
-        dates[datesIndex].endInterval = tempEndInterval;
-      }
-    }
-    dates[datesIndex].startInterval = currDate;
-    currDate = addDays(currDate, 1);
-    datesIndex++;
-  }
+        dayOfWeekIndex++;
+        if (dayOfWeekIndex === 7) {
+            dayOfWeekIndex = 0;
+        }
 
-  while (isAfter(endOfWeek(endDate), currDate)) {
-    dates.push({ isAvailable: false, startInterval: currDate });
-    currDate = addDays(currDate, 1);
-  }
-  return dates;
+        if (dates[datesIndex].isAvailable) {
+            if (nextDayOverFlow) {
+                if (!firstDay) {
+                    let additionalStartInterval = startOfDay(currDate);
+                    let additionalEndInterval = set(new Date(), {
+                        date: getDate(currDate),
+                        hours: getHours(endInterval),
+                        minutes: getMinutes(endInterval),
+                        seconds: getHours(endInterval),
+                        milliseconds: getHours(endInterval),
+                    });
+                    dates[datesIndex].additionalStart = additionalStartInterval;
+                    dates[datesIndex].additionalEnd = additionalEndInterval;
+                }
+                tempStartInterval = setInterval(tempStartInterval, currDate);
+                tempEndInterval = set(new Date(), {
+                    date: getDate(currDate),
+                    hours: 23,
+                    minutes: 59,
+                    seconds: 59,
+                    milliseconds: 59,
+                });
+                dates[datesIndex].startInterval = tempStartInterval;
+                dates[datesIndex].endInterval = tempEndInterval;
+            } else {
+                tempStartInterval = setInterval(tempStartInterval, currDate);
+                tempEndInterval = setInterval(tempEndInterval, currDate);
+                dates[datesIndex].startInterval = tempStartInterval;
+                dates[datesIndex].endInterval = tempEndInterval;
+            }
+        }
+        dates[datesIndex].startInterval = currDate;
+        currDate = addDays(currDate, 1);
+        datesIndex++;
+    }
+
+    while (isAfter(endOfWeek(endDate), currDate)) {
+        dates.push({ isAvailable: false, startInterval: currDate });
+        currDate = addDays(currDate, 1);
+    }
+    return dates;
 }
 
 function setInterval(interval, currDate) {
-  return set(interval, {
-    date: getDate(currDate),
-  });
+    return set(interval, {
+        date: getDate(currDate),
+    });
 }
 
 export function getWeekInterval(startOfWeek) {
-  return [startOfWeek, set(addDays(startOfWeek, 6), { hours: 23, minutes: 59, seconds: 59, milliseconds: 99 })];
+    return [startOfWeek, set(addDays(startOfWeek, 6), { hours: 23, minutes: 59, seconds: 59, milliseconds: 99 })];
 }

--- a/pro-planner-client/src/helpers/Outing.js
+++ b/pro-planner-client/src/helpers/Outing.js
@@ -1,0 +1,107 @@
+// code references https://date-fns.org/docs/Getting-Started
+
+import { isAfter, set, getDay, getHours, getMinutes, addDays, getDate, startOfWeek, endOfWeek, startOfDay, endOfDay } from 'date-fns';
+
+export function processDates(params) {
+  const startInterval = params.dateTimeRange[0][0];
+  const endInterval = params.dateTimeRange[0][1];
+  const endDate = params.dateTimeRange[1];
+
+  let nextDayOverFlow = false;
+  if (getDate(startInterval) !== getDate(endInterval)) {
+    nextDayOverFlow = true;
+  }
+
+  let startWeekForInterval = startOfWeek(startInterval);
+
+  let datesIndex = 0;
+  let dates = [];
+  while (getDay(startInterval) !== getDay(startWeekForInterval)) {
+    dates[datesIndex] = {
+      isAvailable: false,
+      startInterval: startWeekForInterval,
+    };
+    startWeekForInterval = addDays(startWeekForInterval, 1);
+    datesIndex++;
+  }
+
+  dates.push({
+    isAvailable: true,
+    startInterval: startInterval,
+    endInterval: endInterval,
+  });
+  datesIndex++;
+  if (nextDayOverFlow) {
+    dates[0].endInterval = startInterval(startInterval);
+  }
+  let currDate = addDays(startInterval, 1);
+  let tempStartInterval = startInterval;
+  let tempEndInterval = endInterval;
+
+  let dayOfWeekIndex = getDay(startInterval) === 6 ? 0 : getDay(startInterval) + 1;
+
+  let firstDay = true;
+  while (!isAfter(currDate, endDate)) {
+    dates[datesIndex] = {};
+    if (params.availableDays.includes(dayOfWeekIndex)) {
+      dates[datesIndex].isAvailable = true;
+    } else {
+      dates[datesIndex].isAvailable = false;
+    }
+    dayOfWeekIndex++;
+    if (dayOfWeekIndex === 7) {
+      dayOfWeekIndex = 0;
+    }
+
+    if (dates[datesIndex].isAvailable) {
+      if (nextDayOverFlow) {
+        if (!firstDay) {
+          let additionalStartInterval = startOfDay(currDate);
+          let additionalEndInterval = set(new Date(), {
+            date: getDate(currDate),
+            hours: getHours(endInterval),
+            minutes: getMinutes(endInterval),
+            seconds: getHours(endInterval),
+            milliseconds: getHours(endInterval),
+          });
+          dates[datesIndex].additionalStart = additionalStartInterval;
+          dates[datesIndex].additionalEnd = additionalEndInterval;
+        }
+        tempStartInterval = setInterval(tempStartInterval, currDate);
+        tempEndInterval = set(new Date(), {
+          date: getDate(currDate),
+          hours: 23,
+          minutes: 59,
+          seconds: 59,
+          milliseconds: 59,
+        });
+        dates[datesIndex].startInterval = tempStartInterval;
+        dates[datesIndex].endInterval = tempEndInterval;
+      } else {
+        tempStartInterval = setInterval(tempStartInterval, currDate);
+        tempEndInterval = setInterval(tempEndInterval, currDate);
+        dates[datesIndex].startInterval = tempStartInterval;
+        dates[datesIndex].endInterval = tempEndInterval;
+      }
+    }
+    dates[datesIndex].startInterval = currDate;
+    currDate = addDays(currDate, 1);
+    datesIndex++;
+  }
+
+  while (isAfter(endOfWeek(endDate), currDate)) {
+    dates.push({ isAvailable: false, currDate });
+    currDate = addDays(currDate, 1);
+  }
+  return dates;
+}
+
+function setInterval(interval, currDate) {
+  return set(interval, {
+    date: getDate(currDate),
+  });
+}
+
+export function getWeekInterval(startOfWeek) {
+  return [startOfWeek, set(addDays(startOfWeek, 6), { hours: 23, minutes: 59, seconds: 59, milliseconds: 99 })];
+}


### PR DESCRIPTION
Scheduling component added to show available time selections for given weeks in selection. This PR only covers basics for the component, without selection features implemented.

To test the component, navigate to the `/outing` route and modify the constants + params object at the top of the `WeeklyCalendar` component.