### PR TITLE
Fix cost slice

### DIFF
--- a/pro-planner-client/src/store.js
+++ b/pro-planner-client/src/store.js
@@ -16,5 +16,6 @@ export default configureStore({
         poll: pollSlice,
         outingSelections: outingSlice,
         tripSelections: tripSlice,
+        cost: costSlice,
     }),
 });


### PR DESCRIPTION
Fix for cost component, cost slice was removed from the store in the last PR. This is a quick patch to fix main.