### PR TITLE
Fix commit history for connecting poll to backend

### DIFF
--- a/pro-planner-client/.gitignore
+++ b/pro-planner-client/.gitignore
@@ -16,6 +16,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/pro-planner-client/src/components/AddOptionForm.jsx
+++ b/pro-planner-client/src/components/AddOptionForm.jsx
@@ -1,28 +1,21 @@
 import React, {useState} from 'react';
 import {Modal, Button, Form} from "react-bootstrap";
-import {useDispatch} from 'react-redux';
-import {addOption} from "../redux/pollSlice";
-import {v4 as uuidv4} from 'uuid';
+import {useDispatch, useSelector} from 'react-redux';
+import {addOptionAsync} from "../redux/pollSlice";
 import {resetError, setError} from "../redux/errorSlice";
 import {ERR_TYPE} from "../constants";
 
 const MAX_OPTION_LIMIT = 70;
 
-function AddOptionForm({poll, showModal, setShowModal}) {
+function AddOptionForm({poll, pollId, showModal, setShowModal}) {
     const [newOption, setNewOption] = useState("")
     const dispatch = useDispatch();
-
-    let formResult = {
-        pollId: poll.pollId,
-        optionId: uuidv4(),
-        option: newOption,
-        voteCount: 0,
-    }
+    const pollDocumentId = useSelector((state) => state.poll.pollsId)
 
     const handleAddOption = (e) => {
         e.preventDefault();
         const formattedNewOption = newOption.trim();
-        const options = Object.values(poll.options)
+        const options = poll.options || {};
 
         if (formattedNewOption.length === 0) {
             dispatch(setError({
@@ -41,7 +34,9 @@ function AddOptionForm({poll, showModal, setShowModal}) {
             return;
         }
 
-        if (options.find(option => option.option === newOption)) {
+        const optionsArray = Object.values(options);
+
+        if (optionsArray.find(option => option.option === newOption)) {
             dispatch(setError({
                 errType: ERR_TYPE.ERR,
                 disableControl: true,
@@ -51,7 +46,7 @@ function AddOptionForm({poll, showModal, setShowModal}) {
         }
 
         dispatch(resetError());
-        dispatch(addOption(formResult));
+        dispatch(addOptionAsync({newOption, pollDocumentId, pollId}));
         handleCloseModal();
     };
 

--- a/pro-planner-client/src/components/AddPollForm.jsx
+++ b/pro-planner-client/src/components/AddPollForm.jsx
@@ -1,25 +1,17 @@
 import React, {useState} from 'react';
 import {InputGroup, Button, Form, Card, Container} from "react-bootstrap";
-import {v4 as uuidv4} from 'uuid';
 import {useDispatch, useSelector} from 'react-redux';
-import {addPoll} from "../redux/pollSlice";
+import {addPollAsync} from "../redux/pollSlice";
 import {resetError, setError} from "../redux/errorSlice";
 import {ERR_TYPE} from "../constants";
 
 const MAX_QUESTION_LIMIT = 105;
 
-function AddPollForm() {
+function AddPollForm({polls}) {
     const [newQuestion, setNewQuestion] = useState('')
-    const polls = useSelector((state) => Object.values(state.poll.polls))
+    const currPolls = polls || {};
+    const pollDocumentId = useSelector((state) => state.poll.pollsId)
     const dispatch = useDispatch();
-
-
-    let formResult = {
-        pollId: uuidv4(),
-        question: newQuestion,
-        options: {},
-        votedUsers: []
-    }
 
     const handleAddPoll = (e) => {
         e.preventDefault();
@@ -41,7 +33,9 @@ function AddPollForm() {
             return;
         }
 
-        if (polls.find(poll => poll.question === newQuestion)) {
+        const pollsArray = Object.values(currPolls);
+
+        if (pollsArray.find(poll => poll.question === newQuestion)) {
             dispatch(setError({
                 errType: ERR_TYPE.ERR,
                 message: 'Poll already exists, please add a different poll.',
@@ -50,7 +44,7 @@ function AddPollForm() {
         }
 
         dispatch(resetError());
-        dispatch(addPoll(formResult))
+        dispatch(addPollAsync({newQuestion, pollDocumentId}))
         setNewQuestion('')
     }
 

--- a/pro-planner-client/src/components/Option.jsx
+++ b/pro-planner-client/src/components/Option.jsx
@@ -1,22 +1,14 @@
 import React from 'react';
 import {Col, Container, Form, ProgressBar, Row} from "react-bootstrap";
-import {useSelector} from 'react-redux';
 
-function Option({option, poll, setSelectedOption}) {
-
-    const polls = useSelector((state) => Object.values(state.poll.polls))
-    const currPoll = polls.find((p) => p.pollId === poll.pollId);
-    const currPollOptions = Object.values(currPoll.options)
-
-    const currUser = 'User A'; // TODO: fetch current user
+function Option({option, optionId, poll, pollId, currUser, setSelectedOption}) {
 
     const handleRadioChange = (e) => {
         setSelectedOption(e.target.id);
-
     }
 
     const isOptionDisabled = (optionId) => {
-        const votedUser = currPoll.votedUsers.find((u) => u.user === currUser);
+        const votedUser = poll.votedUsers.find((u) => u.user === currUser);
 
         if (votedUser) {
             return votedUser.votedOptionId === optionId;
@@ -31,21 +23,20 @@ function Option({option, poll, setSelectedOption}) {
                 <Row>
                     <Col>
                         <Form.Check
-                            disabled={isOptionDisabled(option.optionId)}
+                            disabled={isOptionDisabled(optionId)}
                             type={'radio'}
                             label={option.option}
-                            name={poll.pollId}
-                            id={option.optionId}
-                            key={option.optionId}
+                            name={pollId}
+                            id={optionId}
                             onChange={handleRadioChange}
                         />
                     </Col>
                     <Col className="d-flex justify-content-end">
-                        {currPollOptions.find((o) => o.optionId === option.optionId).voteCount}
+                        {poll.options[optionId].voteCount}
                     </Col>
                     <Col>
                         <ProgressBar
-                            now={currPollOptions.find((o) => o.optionId === option.optionId).voteCount}
+                            now={poll.options[optionId].voteCount}
                         />
                     </Col>
                 </Row>

--- a/pro-planner-client/src/components/Options.jsx
+++ b/pro-planner-client/src/components/Options.jsx
@@ -3,17 +3,22 @@ import Option from "./Option";
 import {Form} from "react-bootstrap";
 
 
-function Options({poll, setSelectedOption, selectedOption}) {
+function Options({poll, pollId, currUser, setSelectedOption, selectedOption}) {
 
-    const options = Object.values(poll.options)
+    if (poll.options === null || !poll.options) {
+        return <p>Please add an option to vote.</p>;
+    }
 
     return (
         <>
             <Form>
-                {options.map((option) =>
+                {Object.entries(poll.options).map(([key, option]) =>
                     <Option option={option}
-                            key={option.optionId}
+                            optionId={key}
+                            key={key}
                             poll={poll}
+                            pollId={pollId}
+                            currUser={currUser}
                             setSelectedOption={setSelectedOption}
                             selectedOption={selectedOption}
                     />)}

--- a/pro-planner-client/src/components/Poll.jsx
+++ b/pro-planner-client/src/components/Poll.jsx
@@ -11,8 +11,8 @@ import {ERR_TYPE} from "../constants";
 
 function Poll({poll, pollId}) {
 
-    const currUser = 'user1';
-    // const currUser = useSelector((state) => state.user.selectedUser);
+    // const currUser = 'user1'; // testing purpose
+    const currUser = useSelector((state) => state.user.selectedUser);
     const [showModal, setShowModal] = useState(false);
     const [selectedOption, setSelectedOption] = useState('');
     const dispatch = useDispatch();

--- a/pro-planner-client/src/components/Poll.jsx
+++ b/pro-planner-client/src/components/Poll.jsx
@@ -3,29 +3,24 @@ import Options from "./Options";
 import {Button, Accordion} from "react-bootstrap";
 import {useState} from 'react';
 import AddOptionForm from "./AddOptionForm";
-import {useDispatch} from 'react-redux';
-import {voteOption} from "../redux/pollSlice";
+import {useDispatch, useSelector} from 'react-redux';
+import {voteOptionAsync} from "../redux/pollSlice";
 import {resetError, setError} from "../redux/errorSlice";
 import {ERR_TYPE} from "../constants";
 
 
-function Poll({poll}) {
+function Poll({poll, pollId}) {
 
+    const currUser = 'user1';
+    // const currUser = useSelector((state) => state.user.selectedUser);
     const [showModal, setShowModal] = useState(false);
     const [selectedOption, setSelectedOption] = useState('');
     const dispatch = useDispatch();
+    const pollDocumentId = useSelector((state) => state.poll.pollsId);
 
     const handleAddOption = () => {
         setShowModal(true);
     };
-
-    const currUser = 'User A'; // TODO: fetch current user
-
-    let formResult = {
-        pollId: poll.pollId,
-        selectedOption: selectedOption, // selected option ID
-        user: currUser,
-    }
 
     const handleVote = () => {
         if (selectedOption.length === 0) {
@@ -37,7 +32,16 @@ function Poll({poll}) {
         }
 
         dispatch(resetError());
-        dispatch(voteOption(formResult))
+
+        const votedUser = poll.votedUsers.find((u) => u.user === currUser);
+
+        dispatch(voteOptionAsync({
+            currUser: currUser,
+            votedOptionId: votedUser ? votedUser.votedOptionId : null,
+            newVotedOptionId: selectedOption,
+            pollDocumentId: pollDocumentId,
+            pollId: pollId
+        }))
     }
 
     return (
@@ -49,6 +53,8 @@ function Poll({poll}) {
                     <Accordion.Body>
                         <Options style={{marginTop: '10px'}}
                                  poll={poll}
+                                 pollId={pollId}
+                                 currUser={currUser}
                                  setSelectedOption={setSelectedOption}
                                  selectedOption={selectedOption}
                         />
@@ -68,6 +74,7 @@ function Poll({poll}) {
                 </Accordion.Item>
             </Accordion>
             <AddOptionForm poll={poll}
+                           pollId={pollId}
                            showModal={showModal}
                            setShowModal={setShowModal}
             />

--- a/pro-planner-client/src/components/Polls.jsx
+++ b/pro-planner-client/src/components/Polls.jsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import Poll from "./Poll";
 import {Container} from "react-bootstrap";
-import {useSelector} from 'react-redux';
 
-function Polls() {
+function Polls({polls}) {
 
-    const pollList = useSelector((state) => Object.values(state.poll.polls));
+    if (polls === null || !polls) {
+        return;
+    }
+
 
     return (
         <>
             <Container className='d-flex flex-column justify-content-center align-items-center'>
-                {pollList.map((poll) =>
+                {Object.entries(polls).map(([key, poll]) =>
                     <Poll poll={poll}
-                          key={poll.pollId}
+                          pollId={key}
+                          key={key}
                     />)}
             </Container>
         </>

--- a/pro-planner-client/src/index.js
+++ b/pro-planner-client/src/index.js
@@ -19,7 +19,7 @@ import './index.scss';
 const router = createBrowserRouter([
     {
         path: '/',
-        element: <VotePage />,
+        element: <LandingPage />,
         errorElement: <ErrorPage />,
     },
     {

--- a/pro-planner-client/src/index.js
+++ b/pro-planner-client/src/index.js
@@ -19,7 +19,7 @@ import './index.scss';
 const router = createBrowserRouter([
     {
         path: '/',
-        element: <LandingPage />,
+        element: <VotePage />,
         errorElement: <ErrorPage />,
     },
     {

--- a/pro-planner-client/src/redux/pollSlice.js
+++ b/pro-planner-client/src/redux/pollSlice.js
@@ -6,8 +6,7 @@ import {buildServerRoute} from "../helpers/Utils";
 export const getPollAsync = createAsyncThunk(
     'poll/get',
     async ({tripId}) => {
-        const response = await axios.get(`http://localhost:5001/poll/${tripId}`);
-        // const response = await axios.get(buildServerRoute('poll', {tripId}));
+        const response = await axios.get(buildServerRoute('poll', tripId));
         return response.data;
     });
 
@@ -15,8 +14,7 @@ export const addPollAsync = createAsyncThunk(
     'poll/add',
     async ({newQuestion, pollDocumentId}) => {
         const response = await axios.put(
-            // buildServerRoute('poll', {pollDocumentId}),
-            `http://localhost:5001/poll/${pollDocumentId}`,
+            buildServerRoute('poll', pollDocumentId),
             {
                 question: newQuestion
             });
@@ -27,8 +25,7 @@ export const addOptionAsync = createAsyncThunk(
     'poll/option/add',
     async ({newOption, pollDocumentId, pollId}) => {
         const response = await axios.put(
-            // buildServerRoute('poll', 'option', {pollDocumentId}, {pollId}),
-            `http://localhost:5001/poll/option/${pollDocumentId}/${pollId}`,
+            buildServerRoute('poll', 'option', pollDocumentId, pollId),
             {
                 option: newOption
             });
@@ -39,8 +36,7 @@ export const voteOptionAsync = createAsyncThunk(
     'poll/option/vote',
     async ({currUser, votedOptionId, newVotedOptionId, pollDocumentId, pollId}) => {
         const response = await axios.patch(
-            // buildServerRoute('poll', 'vote', {pollDocumentId}, {pollId}),
-            `http://localhost:5001/poll/vote/${pollDocumentId}/${pollId}`,
+            buildServerRoute('poll', 'vote', pollDocumentId, pollId),
             {
                 user: currUser,
                 votedOptionId: votedOptionId,

--- a/pro-planner-client/src/redux/pollSlice.js
+++ b/pro-planner-client/src/redux/pollSlice.js
@@ -1,9 +1,61 @@
-import {createSlice} from "@reduxjs/toolkit";
+import axios from 'axios';
+import {createSlice, createAsyncThunk} from "@reduxjs/toolkit";
+import {LOAD_STATUS} from '../constants';
+import {buildServerRoute} from "../helpers/Utils";
+
+export const getPollAsync = createAsyncThunk(
+    'poll/get',
+    async ({tripId}) => {
+        const response = await axios.get(`http://localhost:5001/poll/${tripId}`);
+        // const response = await axios.get(buildServerRoute('poll', {tripId}));
+        return response.data;
+    });
+
+export const addPollAsync = createAsyncThunk(
+    'poll/add',
+    async ({newQuestion, pollDocumentId}) => {
+        const response = await axios.put(
+            // buildServerRoute('poll', {pollDocumentId}),
+            `http://localhost:5001/poll/${pollDocumentId}`,
+            {
+                question: newQuestion
+            });
+        return response.data;
+    });
+
+export const addOptionAsync = createAsyncThunk(
+    'poll/option/add',
+    async ({newOption, pollDocumentId, pollId}) => {
+        const response = await axios.put(
+            // buildServerRoute('poll', 'option', {pollDocumentId}, {pollId}),
+            `http://localhost:5001/poll/option/${pollDocumentId}/${pollId}`,
+            {
+                option: newOption
+            });
+        return response.data
+    });
+
+export const voteOptionAsync = createAsyncThunk(
+    'poll/option/vote',
+    async ({currUser, votedOptionId, newVotedOptionId, pollDocumentId, pollId}) => {
+        const response = await axios.patch(
+            // buildServerRoute('poll', 'vote', {pollDocumentId}, {pollId}),
+            `http://localhost:5001/poll/vote/${pollDocumentId}/${pollId}`,
+            {
+                user: currUser,
+                votedOptionId: votedOptionId,
+                newVotedOptionId: newVotedOptionId
+            });
+        return response.data;
+    });
+
 
 const pollSlice = createSlice({
     name: 'poll',
     initialState: {
+        pollsId: null, // poll document Id
         polls: {},
+        pollStatus: null,
     },
     reducers: {
         addPoll: (state, action) => {
@@ -31,14 +83,61 @@ const pollSlice = createSlice({
             const poll = state.polls[input.pollId];
             const votedUser = poll.votedUsers.find((u) => u.user === input.user);
             if (votedUser) {
-                poll.options[votedUser.votedOptionId].voteCount-- // decrement previous voted option count
-                votedUser.votedOptionId = input.selectedOption; // update voted option
-                poll.options[input.selectedOption].voteCount++ // increment current voted option count
+                poll.options[votedUser.votedOptionId].voteCount--
+                votedUser.votedOptionId = input.selectedOption;
+                poll.options[input.selectedOption].voteCount++
             } else {
                 poll.votedUsers.push({user: input.user, votedOptionId: input.selectedOption});
                 poll.options[input.selectedOption].voteCount++
             }
         },
+    },
+    extraReducers: (builder) => {
+        builder.addCase(getPollAsync.pending, (state) => {
+            state.pollStatus = LOAD_STATUS.LOADING;
+        });
+        builder.addCase(getPollAsync.fulfilled, (state, action) => {
+            state.polls = action.payload.polls;
+            state.pollsId = action.payload._id;
+            state.pollStatus = LOAD_STATUS.SUCCESS;
+        });
+        builder.addCase(getPollAsync.rejected, (state) => {
+            state.pollStatus = LOAD_STATUS.FAILED;
+        });
+
+        builder.addCase(addPollAsync.pending, (state) => {
+            state.pollStatus = LOAD_STATUS.LOADING;
+        });
+        builder.addCase(addPollAsync.fulfilled, (state, action) => {
+            state.polls = action.payload.polls;
+            state.pollsId = action.payload._id;
+            state.pollStatus = LOAD_STATUS.SUCCESS;
+        });
+        builder.addCase(addPollAsync.rejected, (state) => {
+            state.pollStatus = LOAD_STATUS.FAILED;
+        });
+
+        builder.addCase(addOptionAsync.pending, (state) => {
+            state.pollStatus = LOAD_STATUS.LOADING;
+        });
+        builder.addCase(addOptionAsync.fulfilled, (state, action) => {
+            state.polls = action.payload.polls;
+            state.pollStatus = LOAD_STATUS.SUCCESS;
+        });
+        builder.addCase(addOptionAsync.rejected, (state) => {
+            state.pollStatus = LOAD_STATUS.FAILED;
+        });
+
+        builder.addCase(voteOptionAsync.pending, (state) => {
+            state.pollStatus = LOAD_STATUS.LOADING;
+        });
+        builder.addCase(voteOptionAsync.fulfilled, (state, action) => {
+            state.polls = action.payload.polls;
+            state.pollStatus = LOAD_STATUS.SUCCESS;
+        });
+        builder.addCase(voteOptionAsync.rejected, (state) => {
+            state.pollStatus = LOAD_STATUS.FAILED;
+        });
     }
 })
 

--- a/pro-planner-client/src/routes/VotePage.jsx
+++ b/pro-planner-client/src/routes/VotePage.jsx
@@ -1,11 +1,29 @@
-import React from "react";
+import React, {useEffect} from "react";
 import AddPollForm from "../components/AddPollForm";
 import Polls from "../components/Polls";
+import {getPollAsync} from "../redux/pollSlice";
+import {useDispatch, useSelector} from "react-redux";
+import {LOAD_STATUS} from "../constants";
+import LoadingDisplay from "../components/LoadingDisplay";
+import {useLocation} from "react-router";
 
 const VotePage = () => {
+
+    const tripId = '64c5cbf8b6cdc4ef3c78be6a'; // testing purpose
+    // const tripId = useLocation().pathname.split('/')[1];
+    const polls = useSelector((state) => state.poll.polls);
+    const loadingState = useSelector((state) => state.poll.pollStatus);
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        dispatch(getPollAsync({tripId}))
+    }, [dispatch])
+
+
     return <>
-        <AddPollForm/>
-        <Polls/>
+        {(loadingState === LOAD_STATUS.LOADING) && <LoadingDisplay/>}
+        <AddPollForm polls={polls}/>
+        <Polls polls={polls}/>
     </>
 };
 

--- a/pro-planner-client/src/routes/VotePage.jsx
+++ b/pro-planner-client/src/routes/VotePage.jsx
@@ -9,8 +9,8 @@ import {useLocation} from "react-router";
 
 const VotePage = () => {
 
-    const tripId = '64c5cbf8b6cdc4ef3c78be6a'; // testing purpose
-    // const tripId = useLocation().pathname.split('/')[1];
+    // const tripId = '64c5cbf8b6cdc4ef3c78be6a'; // testing purpose
+    const tripId = useLocation().pathname.split('/')[1];
     const polls = useSelector((state) => state.poll.polls);
     const loadingState = useSelector((state) => state.poll.pollStatus);
     const dispatch = useDispatch();

--- a/pro-planner-server/routes/poll.js
+++ b/pro-planner-server/routes/poll.js
@@ -8,119 +8,152 @@
 const express = require('express');
 const router = express.Router();
 const poll = require('../models/poll');
-const { ObjectId } = require('mongodb');
+const {ObjectId} = require('mongodb');
 
 // gets the entire poll document, needs the eventId (id of trip/outing)
-router.get('/:id', async (req, res) => {
-  const polls = await poll.findOne({ eventId: new Object(req.params.eventId) }, { __v: false });
-  res.json(polls);
+router.get('/:eventId', async (req, res) => {
+  try {
+    const polls = await poll.findOne({eventId: new Object(req.params.eventId)}, {__v: false});
+    res.status(200).json(polls);
+  } catch (error) {
+    res.status(500).send(`Unexpected error: ${error}`)
+  }
 });
 
 // adds new poll into the polls
 // needs id of the poll document
 router.put('/:id', async (req, res) => {
-  const pollId = new ObjectId();
-  const addedPoll = await poll.findOneAndUpdate(
-    { _id: new ObjectId(req.params.id) },
-    {
-      $set: {
-        [`polls.${pollId}`]: {
-          question: req.body.question,
-          options: {
-            voteUser: [],
+  try {
+    const pollId = new ObjectId();
+    const addedPoll = await poll.findOneAndUpdate(
+        {_id: new ObjectId(req.params.id)},
+        {
+          $set: {
+            [`polls.${pollId}`]: {
+              question: req.body.question,
+              options: {},
+              votedUsers: [],
+            },
           },
         },
-      },
-    },
-    {
-      new: true,
-      projection: {
-        __v: false,
-      },
+        {
+          new: true,
+          projection: {
+            __v: false,
+          },
+        }
+    );
+    if (addedPoll) {
+      res.status(200).json(addedPoll);
+    } else {
+      res.status(404).send("Poll not added")
     }
-  );
-  res.json(addedPoll);
+  } catch (error) {
+    res.status(500).send(`Unexpected error: ${error}`)
+  }
 });
 
 // adds a new option
 // needs id of the poll document and the poll id under polls
 router.put('/option/:id/:pollId', async (req, res) => {
-  const optionId = new ObjectId();
-  const addOption = {
-    option: req.body.option,
-    voteCount: 0,
-  };
-  const addedPoll = await poll.findOneAndUpdate(
-    { _id: new ObjectId(req.params.id) },
-    {
-      $set: {
-        [`polls.${req.params.pollId}.options.${optionId}`]: addOption,
-      },
-    },
-    {
-      new: true,
-      projection: {
-        __v: false,
-      },
+  try {
+    const optionId = new ObjectId();
+    const optionToAdd = {
+      option: req.body.option,
+      voteCount: 0,
+    };
+
+
+    const addedPoll = await poll.findOneAndUpdate(
+        {_id: new ObjectId(req.params.id)},
+        {
+          $set: {
+            [`polls.${req.params.pollId}.options.${optionId}`]: optionToAdd,
+          },
+        },
+        {
+          new: true,
+          projection: {
+            __v: false,
+          },
+        }
+    );
+
+    if (addedPoll) {
+      res.status(200).json(addedPoll);
+    } else {
+      res.status(404).send("Option not added");
     }
-  );
-  res.json(addedPoll);
+
+  } catch (error) {
+    res.status(500).send(`Unexpected error: ${error}`)
+  }
 });
 
 // handles when users make a vote (updates the voteCount under options & updates the user's votedOptionId under voteUsers)
 // needs id of the poll document, the poll id under polls, user's name (user field), user's existing votedOptionId (null if they didn't vote before), and new option id
 router.patch('/vote/:id/:pollId', async (req, res) => {
-  const id = req.params.id;
-  const pollId = req.params.pollId;
-  const user = req.body.user;
-  const currUserVoteId = req.body.votedOptionId;
-  const newVotedOptionId = req.body.newVotedOptionId;
+  try {
+    const id = req.params.id;
+    const pollId = req.params.pollId;
+    const currUser = req.body.user;
+    const votedOptionId = req.body.votedOptionId;
+    const newVotedOptionId = req.body.newVotedOptionId;
 
-  // decrements prev user vote in options
-  if (currUserVoteId) {
-    await poll.updateOne(
-      { _id: new ObjectId(id) },
-      {
-        $inc: {
-          [`polls.${pollId}.options.${currUserVoteId}.voteCount`]: -1,
-        },
-      }
-    );
-  } else {
-    // new user vote (adds to the voteUsers array)
-    const userInfo = {
-      user: user,
-      votedOptionId: null,
-    };
-    await poll.updateOne(
-      { _id: new ObjectId(id) },
-      {
-        $push: {
-          [`polls.${pollId}.options.voteUsers`]: userInfo,
-        },
-      }
-    );
-  }
-
-  // update new user votedOptionId & inc voteCount for selected option
-  const updatedPoll = await poll.findOneAndUpdate(
-    { _id: new Object(id), [`polls.${pollId}.options.voteUsers.user`]: user },
-    {
-      $set: {
-        [`polls.${pollId}.options.voteUsers.$.votedOptionId`]: new ObjectId(newVotedOptionId),
-      },
-      $inc: {
-        [`polls.${pollId}.options.${newVotedOptionId}.voteCount`]: 1,
-      },
-    },
-    {
-      new: true,
-      projection: {
-        __v: false,
-      },
+    // decrements prev user vote in options
+    if (votedOptionId || votedOptionId !== null) {
+      await poll.updateOne(
+          {_id: new ObjectId(id)},
+          {
+            $inc: {
+              [`polls.${pollId}.options.${votedOptionId}.voteCount`]: -1,
+            },
+          }
+      );
+    } else {
+      // new user vote (adds to the voteUsers array)
+      const userInfo = {
+        user: currUser,
+        votedOptionId: null,
+      };
+      await poll.updateOne(
+          {_id: new ObjectId(id)},
+          {
+            $push: {
+              [`polls.${pollId}.votedUsers`]: userInfo,
+            },
+          }
+      );
     }
-  );
-  res.json(updatedPoll);
+
+    // update new user votedOptionId & inc voteCount for selected option
+    const updatedPoll = await poll.findOneAndUpdate(
+        {_id: new Object(id), [`polls.${pollId}.votedUsers.user`]: currUser},
+        {
+          $set: {
+            [`polls.${pollId}.votedUsers.$.votedOptionId`]: new ObjectId(newVotedOptionId),
+          },
+          $inc: {
+            [`polls.${pollId}.options.${newVotedOptionId}.voteCount`]: 1,
+          },
+        },
+        {
+          new: true,
+          projection: {
+            __v: false,
+          },
+        }
+    );
+
+    if (updatedPoll) {
+      res.status(200).json(updatedPoll);
+    } else {
+      res.status(404).send("Not voted");
+    }
+
+  } catch (error) {
+    res.status(500).send(`Unexpected error: ${error}`)
+  }
 });
 
 module.exports = router;


### PR DESCRIPTION
This PR replaces the https://github.com/rikili/ProPlanner/pull/28 and covers:

- Fixing commit history issue in the previous PR
- Connecting `VotePage` to backend

To test, run both frontend and backend with mongoDB connection. You can access to the existing poll document in the db and change `currUser` in `Poll` component to simulate the voting page with multiple users.