### PR TITLE
Remove usage of ISO strings in outing format + edit edge case

### DIFF
--- a/pro-planner-client/src/components/OutingCalendar.jsx
+++ b/pro-planner-client/src/components/OutingCalendar.jsx
@@ -22,7 +22,7 @@ import {
 } from 'date-fns';
 import { Card } from 'react-bootstrap';
 import { getMonthIndex } from '../helpers/Calendar';
-import { generateSlots, selectToInterval, getTime, getEndOfSegment, isLooseEndOfDay, isTimeBefore } from '../helpers/OutingCalendar';
+import { generateSlots, selectToInterval, getTime, getEndOfSegment, isLooseEndOfDay, isTimeBefore, makeOutingDate } from '../helpers/OutingCalendar';
 import { resetUpdateFailed, setLoading, setUserSelections, updateOutings } from '../redux/outingSlice';
 
 import OutingDay from './OutingDay';
@@ -227,7 +227,6 @@ function OutingCalendar({ planId }) {
     );
     const [isEditing, setEditing] = useState(false);
     const [monthsToUpdate, setUpdateMonths] = useState([]);
-    const [firstLoad, setFirstLoad] = useState(false);
     const dispatch = useDispatch();
 
     let slots = useMemo(() => generateSlots(params), [params]);
@@ -355,8 +354,8 @@ function OutingCalendar({ planId }) {
                 planId,
                 planType: PLAN_TYPE.OUTING,
                 range: [
-                    decisionPreview[0].toISOString(),
-                    decisionPreview[1].toISOString(),
+                    makeOutingDate(decisionPreview[0]),
+                    makeOutingDate(decisionPreview[1]),
                 ]
             })
         );

--- a/pro-planner-client/src/components/OutingDay.jsx
+++ b/pro-planner-client/src/components/OutingDay.jsx
@@ -1,5 +1,5 @@
 import { eachMinuteOfInterval, format, isAfter, isWithinInterval, startOfDay, subMinutes, endOfDay, isEqual, parseISO } from "date-fns";
-import { selectToInterval, getEndOfSegment, SEGMENT_TIME } from '../helpers/OutingCalendar';
+import { selectToInterval, getEndOfSegment, SEGMENT_TIME, makeOutingDate } from '../helpers/OutingCalendar';
 import { assembleClass } from '../helpers/Utils';
 
 import { useDispatch, useSelector } from "react-redux";
@@ -23,7 +23,7 @@ const OutingDay = ({
     maxUsers,
 }) => {
     const dispatch = useDispatch();
-    const decision = useSelector(state => state.planParameters.decisionRange).map((isoString) => new Date(isoString));
+    const decision = useSelector(state => state.planParameters.decisionRange).map((outingString) => new Date(outingString));
     const summaryState = useSelector(state => state.summary.detailedDay);
     const summaryDate = summaryState ? new Date(summaryState) : null;
     const isDecision = !!decision.length;
@@ -103,7 +103,7 @@ const OutingDay = ({
                     dispatch(setDetailedDay(null));
                     dispatch(setDetailedUsers([]));
                 } else {
-                    dispatch(setDetailedDay(segmentStart.toISOString()));
+                    dispatch(setDetailedDay(makeOutingDate(segmentStart)));
                     dispatch(setDetailedUsers([...isSelected]));
                 }
             }

--- a/pro-planner-client/src/components/ParameterForm.jsx
+++ b/pro-planner-client/src/components/ParameterForm.jsx
@@ -9,6 +9,7 @@ import InputDetailsForm from '../components/InputDetailsForm';
 import TimeRangeForm from '../components/TimeRangeForm';
 import { setError } from '../redux/errorSlice';
 import { ERR_TYPE, PLAN_TYPE } from '../constants';
+import { makeOutingDate } from '../helpers/OutingCalendar';
 
 const MAX_TRIP_MONTH_RANGE = 12;
 const MAX_OUTING_MONTH_RANGE = 5;
@@ -275,7 +276,7 @@ const ParameterForm = ({ title, onSubmit, editDetails = null, showBack = false }
             }
 
             formResult.isAllDay = false;
-            formResult.dateTimeRange = [[startDateTime.toISOString(), startEndTime.toISOString()], endDate.toISOString()];
+            formResult.dateTimeRange = [[makeOutingDate(startDateTime), makeOutingDate(startEndTime)], makeOutingDate(endDate)];
         } else {
             startDateTime = new Date(`${startString}, ${START_DAY_TIME}`);
             const endDate = new Date(`${endString}, ${END_DAY_TIME}`);

--- a/pro-planner-client/src/helpers/OutingCalendar.js
+++ b/pro-planner-client/src/helpers/OutingCalendar.js
@@ -44,6 +44,8 @@ export const isTimeBefore = (firstTime, secTime, checkEqual = false) => {
             : buildDate(new Date(), firstTime) < buildDate(new Date(), secTime);
 }
 
+export const makeOutingDate = (date) => format(date, 'yyyy-MM-dd HH:mm');
+
 const getDayFromTemplate = (date, template, cutoff = null) => {
     if (!cutoff) cutoff = endOfDay(date);
     const dayArr = [];

--- a/pro-planner-client/src/routes/EditPage.jsx
+++ b/pro-planner-client/src/routes/EditPage.jsx
@@ -3,19 +3,27 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 import { buildServerRoute } from '../helpers/Utils';
 import { setError } from '../redux/errorSlice';
-import { ERR_TYPE } from '../constants';
+import { ERR_TYPE, PLAN_TYPE } from '../constants';
 import { updatePlan } from '../redux/planParamSlice';
 import axios from 'axios';
 import LoadingDisplay from '../components/LoadingDisplay';
 import ParameterForm from '../components/ParameterForm';
+import { isAfter, isBefore } from 'date-fns';
 
 const EditPage = () => {
     const [isUploading, setIsUploading] = useState(false);
     const { tripId } = useParams();
     const navigate = useNavigate();
     const dispatch = useDispatch();
-
+    const decision = useSelector(state => state.planParameters.decisionRange);
     const params = useSelector((state) => state.planParameters);
+
+    const checkDecisionInRange = (dateRange, planType) => {
+        if (!decision.length) return false;
+        const startTime = (planType === PLAN_TYPE.OUTING) ? dateRange[0][0] : dateRange[0];
+        const endTime = dateRange[1];
+        return isBefore(new Date(decision[0]), new Date(startTime)) || isAfter(new Date(decision[1]), new Date(endTime));
+    }
 
     const existingData = {
         name: params.name,
@@ -29,8 +37,13 @@ const EditPage = () => {
     };
 
     const handleSubmission = (formResult, planType) => {
+        let shouldClearDecision = false;
+        if (checkDecisionInRange(formResult.dateTimeRange, planType)) {
+            shouldClearDecision = true;
+        }
+
         axios
-            .put(buildServerRoute('plan', tripId), { ...formResult, planType })
+            .put(buildServerRoute('plan', tripId), { ...formResult, planType, decision: shouldClearDecision ? [] : decision })
             .then((result) => {
                 dispatch(updatePlan(result.data));
                 setIsUploading(false);

--- a/pro-planner-server/routes/plan.js
+++ b/pro-planner-server/routes/plan.js
@@ -32,6 +32,7 @@ router.put('/:id', async (req, res) => {
     location: data.location,
     dateTimeRange: data.dateTimeRange,
     description: data.description,
+    decision: data.decision,
   };
   try {
     let updatedParams = await plan.findOneAndUpdate(


### PR DESCRIPTION
Due to not supporting timezone adjustment in outings, ISO strings will not longer be used due to possible conversion issues.

Covered in this PR also is a clearing of a decision if a plan is edited to no longer contain the decision.