### PR TITLE
Reset selected user on deletion + fix error toast clearing + error page styling

### DIFF
--- a/pro-planner-client/src/components/ErrorToast.jsx
+++ b/pro-planner-client/src/components/ErrorToast.jsx
@@ -29,6 +29,9 @@ const ErrorToast = forwardRef((_, ref) => {
     const dispatch = useDispatch();
 
     const closeToast = () => {
+        if (closeToastTimeout) {
+            clearTimeout(closeToastTimeout);
+        }
         setShow(false);
         if (errRedir) navigate(errRedir);
         dispatch(resetError());
@@ -47,15 +50,17 @@ const ErrorToast = forwardRef((_, ref) => {
             if (doSetTimeout) closeToastTimeout = setAutohideTimer();
         }
 
+        if (!showError && show) {
+            setShow(false);
+            closeToast();
+        }
+
         if (errTime) {
             if (doSetTimeout) resetTimeout();
         }
     }, [showError, errTime]);
 
     const handleCloseToast = () => {
-        if (closeToastTimeout) {
-            clearTimeout(closeToastTimeout);
-        }
         closeToast();
     }
 

--- a/pro-planner-client/src/components/UserList.jsx
+++ b/pro-planner-client/src/components/UserList.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useSelector, useDispatch} from 'react-redux';
-import {deleteUsersAsync, selectUser} from '../redux/userSlice';
+import {deleteUsersAsync, resetUser, selectUser} from '../redux/userSlice';
 import {updatePollAsync} from "../redux/pollSlice";
 import {useNavigate} from 'react-router-dom';
 import {useParams} from 'react-router-dom';
@@ -78,6 +78,7 @@ const UserList = () => {
         if (usersToDelete.length !== 0) {
             dispatch(deleteUsersAsync({planId: tripId, usersToDelete}));
             dispatch(updatePollAsync({pollDocumentId, usersToDelete}));
+			dispatch(resetUser());
         }
         setUsersToDelete([]);
         setIsEditing(false);

--- a/pro-planner-client/src/routes/ErrorPage.jsx
+++ b/pro-planner-client/src/routes/ErrorPage.jsx
@@ -1,12 +1,33 @@
-import { useRouteError } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useNavigate, useRouteError } from 'react-router-dom';
 
+let timeoutTrack;
 const ErrorPage = () => {
     const error = useRouteError();
-    console.error(error);
+    const navigate = useNavigate();
 
-    return <p>
-        <b>404 Page Not Found.</b> There seems to be an error with the URL path.
-    </p>
-}
+    useEffect(() => {
+        if (timeoutTrack) {
+            clearTimeout(timeoutTrack);
+            timeoutTrack = null;
+        }
+        timeoutTrack = setTimeout(() => {
+            timeoutTrack = null;
+            navigate('/');
+        }, 5000);
+    }, []);
+
+    return (
+        <div className="d-flex justify-content-center align-items-center vh-100 flex-column">
+            <h1 className="mb-3" style={{color: "rgb(23, 69, 126)"}}>ProPlanner</h1>
+            <p className="text-center" style={{fontSize: '1.3em'}}>
+                <b>{`${error.status} ${error.statusText}.`}</b>
+                <br />
+                Seems like you've ended up somewhere you shouldn't be<br/>
+            </p>
+            <p style={{color: 'grey'}}>You will be redirected shortly. . .</p>
+        </div>
+    );
+};
 
 export default ErrorPage;


### PR DESCRIPTION
Covered in PR:
* reset selected user when deletion occurs to prevent loggin in to deleted user
* fix clearing of error toast when done through redux state (and not user action/timeout)
* style error page and add timeout to redirect to landing page